### PR TITLE
set root route and resolved known issue with jquery turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'coffee-rails', '~> 4.1.0'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
+gem 'jquery-turbolinks'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.2)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
@@ -164,6 +167,7 @@ DEPENDENCIES
   fitgem
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   pg
   pry
   rails (= 4.2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  
+  root 'users#index'
+
   resources :users, only: [:show, :index]
   resources :daily_activites 
 


### PR DESCRIPTION
- set root to /users
- there is a known issue with Rails, turbolinks, and jQuery. Basically when you navigate from one page to another, turbolinks doesn't reload jQuery, which is obviously a problem for us: users/:id would only render the dynamic skyscraper and do an Ajax call after you navigated to the page AND reloaded it.
- this is solved by a gem called 'jquery-turbolinks' which you have to add to the Gemfile and include in the application.js manifest.
- you will need to bundle when you pull down again
